### PR TITLE
align code with phpdb 0.3.x-dev

### DIFF
--- a/src/Driver/Mysqli/Connection.php
+++ b/src/Driver/Mysqli/Connection.php
@@ -58,7 +58,7 @@ class Connection extends AbstractConnection implements DriverAwareInterface
 
     /** @inheritDoc */
     #[Override]
-    public function getCurrentSchema(): string|bool
+    public function getCurrentSchema(): string|false
     {
         if (! $this->isConnected()) {
             $this->connect();

--- a/src/Driver/Pdo/Connection.php
+++ b/src/Driver/Pdo/Connection.php
@@ -24,7 +24,7 @@ class Connection extends AbstractPdoConnection
      * {@inheritDoc}
      */
     #[Override]
-    public function getCurrentSchema(): string|bool
+    public function getCurrentSchema(): string|false
     {
         if (! $this->isConnected()) {
             $this->connect();


### PR DESCRIPTION
Signed-off-by: Joey Smith <jsmith@webinertia.net>

Signed-off-by: Joey Smith <jsmith@webinertia.net>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
| House Keeping | yes

### Description

This aligns code with return type changes for SchemaAwareInterface::getCurrentSchema(): string|false. Return type was narrowed from string|bool in the Interface when min php version was bumped to 8.2 and false is supported as a standalone type.
